### PR TITLE
Fixed GAN ignoring AE param

### DIFF
--- a/generate_samples_main.py
+++ b/generate_samples_main.py
@@ -103,7 +103,7 @@ def main():
                             activation=state_dict['configuration']['activation'],
                             input_sequence_length=input_sequence_length,
                             patch_size=state_dict['configuration']['patch_size'],
-                            path_autoencoder=state_dict['configuration']['autoencoder'],
+                            autoencoder=state_dict['configuration']['autoencoder'],
                             padding=state_dict['configuration']['padding'],
                             )
     generator.eval()

--- a/helpers/initialize_gan.py
+++ b/helpers/initialize_gan.py
@@ -33,11 +33,11 @@ def init_gan(gan_type,
              activation='tanh', 
              input_sequence_length=0, 
              patch_size=-1, 
-             path_autoencoder='',
+             autoencoder='',
              padding=0,
              **kwargs,
              ):
-    if path_autoencoder == '':
+    if autoencoder == '':
         # no autoencoder defined -> use transformer GAN
         generator = gan_architectures[gan_types[gan_type][0]](
             # FFGenerator inputs: latent_dim, channels, hidden_dim, num_layers, dropout, activation
@@ -74,7 +74,7 @@ def init_gan(gan_type,
         # initialize an autoencoder-GAN
 
         # initialize the autoencoder
-        ae_dict = torch.load(path_autoencoder, map_location=torch.device('cpu'))
+        ae_dict = torch.load(autoencoder, map_location=torch.device('cpu'))
         if ae_dict['configuration']['target'] == 'channels':
             ae_dict['configuration']['target'] = TransformerAutoencoder.TARGET_CHANNELS
             autoencoder = TransformerAutoencoder(**ae_dict['configuration']).to(device)


### PR DESCRIPTION
This is in response to issue #86. 

It turns out that `generate_samples_main.py` was breaking because the GAN in `gan_training_main.py` was ignoring the autoencoder param and so was not in fact training an AE-GAN. This happened because the user param `path_autoencoder` had been renamed to `autoencoder` but this was not changed in the `init_gan` function nor in the `generate_samples_main` script.

This PR made these changes to fix the issue.